### PR TITLE
composer support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -110,6 +110,7 @@ module.exports = function( grunt ) {
 					'!build/**',
 					'!Gruntfile.js',
 					'!package.json',
+					'!composer.json',
 					'!LICENSE',
 					'!README.md',
 					'!assets/**',

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+	"name"        : "black-studio/black-studio-tinymce-widget",
+	"description" : "Adds a new 'Visual Editor' widget type based on the native WordPress TinyMCE editor.",
+	"keywords"    : ["wordpress", "wysiwyg", "widget", "visual editor"],
+	"type"        : "wordpress-plugin",
+	"homepage"    : "https://wordpress.org/plugins/black-studio-tinymce-widget/",
+	"license"     : "GPL-3.0",
+	"authors": [
+    {
+      "name"     : "Black Studio",
+      "email"    : "info@blackstudio.it",
+      "homepage" : "http://www.blackstudio.it"
+    },
+    {
+      "name"     : "Marco Chiesi",
+      "email"    : "marco@blackstudio.it",
+      "homepage" : "http://www.blackstudio.it"
+    }
+  ],
+	"support"     : {
+		"issues": "https://github.com/black-studio/black-studio-tinymce-widget/issues"
+	},
+	"require"     : {
+		"composer/installers": "~1.0"
+	}
+}


### PR DESCRIPTION
allow the plugin to be required in a composer project directly from the repo without the need for wpackagist.org to be up and running
