### PR TITLE
Update black-studio-tinymce-widget.php

### DIFF
--- a/black-studio-tinymce-widget.php
+++ b/black-studio-tinymce-widget.php
@@ -236,7 +236,7 @@ if ( ! class_exists( 'Black_Studio_TinyMCE_Plugin' ) ) {
 		 * @since 2.0.0
 		 */
 		public function check_widget( $widget ) {
-			return gettype( $widget ) == 'object' && get_class( $widget ) == 'WP_Widget_Black_Studio_TinyMCE';
+			return gettype( $widget ) == 'object' && (get_class( $widget ) == 'WP_Widget_Black_Studio_TinyMCE' || is_subclass_of($widget , 'WP_Widget_Black_Studio_TinyMCE'));
 		}
 
 	} // END class Black_Studio_TinyMCE_Plugin


### PR DESCRIPTION
Hello 

if WP_Widget_Black_Studio_TinyMCE class is extended the method check_widget fails the check.
The change makes the widget extensible