### PR TITLE
Bump adm-zip to 0.6.0 (fix CVE-2026-39244)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,13 +52,13 @@
       "license": "ISC"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "overrides": {
     "minimatch": ">=3.1.4",
-    "tmp": ">=0.2.6"
+    "tmp": ">=0.2.6",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "grunt": "^1.5.3",


### PR DESCRIPTION
Forza `adm-zip >= 0.6.0` via npm `overrides` per chiudere l'alert Dependabot **GHSA-xcpc-8h2w-3j85** (CVE-2026-39244, high severity: crafted ZIP triggers 4GB memory allocation).

`adm-zip` e' una dipendenza dev transitiva (via `grunt-contrib-compress`): Dependabot non ha aperto la PR da solo perche' il fix e' un salto major annidato. Stesso pattern degli override gia' presenti (`minimatch`, `tmp`).

Nessun impatto runtime: il plugin non ha `dependencies` di produzione, solo toolchain di build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)