### PR TITLE
Bump js-yaml to 3.15.0 (fix GHSA-h67p-54hq-rp68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2240,9 +2240,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "overrides": {
     "minimatch": ">=3.1.4",
     "tmp": ">=0.2.6",
-    "adm-zip": "^0.6.0"
+    "adm-zip": "^0.6.0",
+    "js-yaml": "^3.15.0"
   },
   "devDependencies": {
     "grunt": "^1.5.3",


### PR DESCRIPTION
Forza `js-yaml >= 3.15.0` via npm `overrides` per chiudere l'alert Dependabot **GHSA-h67p-54hq-rp68** (medium severity). Dipendenza dev transitiva, bump minor entro la linea 3.x. Nessun impatto runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)